### PR TITLE
fix user curation cast api data fields

### DIFF
--- a/hooks/user/useUserCurationCasts.ts
+++ b/hooks/user/useUserCurationCasts.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { fetchItems, selectUserCurationCasts } from "~/features/user/userCurationCastsSlice";
 import { AsyncRequestStatus } from "~/services/shared/types";
 
-export default function useUserCasts(fid?: number, viewer_fid?: number) {
+export default function useUserCurationCasts(fid?: number, viewer_fid?: number) {
   const dispatch = useDispatch();
   const { items, status, error } = useSelector(selectUserCurationCasts);
 

--- a/services/feeds/api/user.ts
+++ b/services/feeds/api/user.ts
@@ -31,7 +31,7 @@ export type UserCurationCastsParams = {
 };
 export function getUserCurationCasts(
   params: UserCurationCastsParams,
-): RequestPromise<ApiResp<UserCastsData>> {
+): RequestPromise<ApiResp<Array<CastData>>> {
   return request({
     url: `/topics/channels/curator/casts`,
     method: "get",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced pagination management for user curation casts, starting page number is now set to 1 for improved user experience.
  
- **Improvements**
  - Refined logic for fetching user curation casts, ensuring API calls are made only with valid pagination.
  - Better handling of the response data for user curation casts, increasing robustness of pagination functionality.

- **Refactor**
  - Renamed hook from `useUserCasts` to `useUserCurationCasts` for clarity on its purpose.

- **Documentation**
  - Updated return type for the `getUserCurationCasts` function to reflect changes in the expected data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->