### PR TITLE
feat: Add proposal share modal to global

### DIFF
--- a/components/StateUpdateWrapper.tsx
+++ b/components/StateUpdateWrapper.tsx
@@ -13,6 +13,7 @@ import OnboardingModal from "./portfolio/onboarding/Onboarding";
 import InviteCodeModal from "./portfolio/onboarding/InviteCodeModal";
 import useUserInvitationCodes from "~/hooks/user/useUserInvitationCodes";
 import useUserHostChannels from "~/hooks/user/useUserHostChannels";
+import ProposalShareGlobalModal from "./social-farcaster/proposal/proposal-modals/ProposalShareGlobalModal";
 
 export default function StateUpdateWrapper({ children }: PropsWithChildren) {
   const { currFid } = useFarcasterAccount();
@@ -100,6 +101,7 @@ export default function StateUpdateWrapper({ children }: PropsWithChildren) {
       {children}
       <OnboardingModal />
       <InviteCodeModal />
+      <ProposalShareGlobalModal />
     </>
   );
 }

--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -4,7 +4,8 @@ import { cn } from "~/lib/utils";
 export function Loading() {
   return (
     <View className="flex h-full w-full items-center justify-center">
-      <ActivityIndicator color={SECONDARY_COLOR} />
+      {/* <ActivityIndicator color={SECONDARY_COLOR} /> */}
+      <ActivityIndicator />
       {/* <Text className=" text-xl text-secondary">Loading...</Text> */}
     </View>
   );

--- a/components/social-farcaster/FCastActions.tsx
+++ b/components/social-farcaster/FCastActions.tsx
@@ -85,10 +85,10 @@ export const FCastMenuButton = forwardRef(function (
     setOpenGiftModal(true);
   };
 
-  const { upsetProposalShareModal } = useAppModals();
+  const { upsertProposalShareModal } = useAppModals();
   const onShare = () => {
     setOpenShareModal(true);
-    upsetProposalShareModal({ open: true, cast, channel: communityInfo });
+    upsertProposalShareModal({ open: true, cast, channel: communityInfo });
   };
   return (
     <View className="z-20">

--- a/components/social-farcaster/FCastActions.tsx
+++ b/components/social-farcaster/FCastActions.tsx
@@ -14,15 +14,7 @@ import { NeynarCast } from "~/services/farcaster/types/neynar";
 import { getCastHex } from "~/utils/farcaster/cast-utils";
 import useAuth from "~/hooks/user/useAuth";
 import useCastReply from "~/hooks/social-farcaster/useCastReply";
-import PlatformSharingModal from "../platform-sharing/PlatformSharingModal";
-import {
-  getCastProposalShareTextWithTwitter,
-  getCastProposalShareTextWithWarpcast,
-} from "~/utils/platform-sharing/text";
-import {
-  getCastDetailWebsiteLink,
-  getVoteProposalFrameLink,
-} from "~/utils/platform-sharing/link";
+import useAppModals from "~/hooks/useAppModals";
 
 export const FCastMenuButton = forwardRef(function (
   {
@@ -93,8 +85,10 @@ export const FCastMenuButton = forwardRef(function (
     setOpenGiftModal(true);
   };
 
+  const { upsetProposalShareModal } = useAppModals();
   const onShare = () => {
     setOpenShareModal(true);
+    upsetProposalShareModal({ open: true, cast, channel: communityInfo });
   };
   return (
     <View className="z-20">
@@ -134,17 +128,6 @@ export const FCastMenuButton = forwardRef(function (
         open={openShareModal}
         onOpenChange={setOpenShareModal}
       /> */}
-      <PlatformSharingModal
-        open={openShareModal}
-        onOpenChange={setOpenShareModal}
-        warpcastText={getCastProposalShareTextWithWarpcast()}
-        twitterText={getCastProposalShareTextWithTwitter()}
-        websiteLink={getCastDetailWebsiteLink(getCastHex(cast))}
-        warpcastEmbeds={[getVoteProposalFrameLink(getCastHex(cast))]}
-        warpcastChannelId={channelId}
-        hideWarpcastPoints
-        hideTwitterPoints
-      />
       <FCastMintNftModal
         cast={cast}
         channelId={channelId}

--- a/components/social-farcaster/proposal/proposal-modals/ChallengeProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ChallengeProposalModal.tsx
@@ -142,7 +142,7 @@ function ChallengeProposalContentBody({
 }: CastProposeStatusProps & {
   onClose: () => void;
 }) {
-  const { upsetProposalShareModal } = useAppModals();
+  const { upsertProposalShareModal } = useAppModals();
   return (
     <View className="flex w-full flex-col gap-4">
       <View className="flex-row items-center justify-between gap-2">
@@ -169,7 +169,7 @@ function ChallengeProposalContentBody({
             type: "success",
             text1: "Submitted",
           });
-          upsetProposalShareModal({ open: true, cast, channel });
+          upsertProposalShareModal({ open: true, cast, channel });
         }}
         onDisputeError={(error) => {
           onClose();
@@ -185,7 +185,7 @@ function ChallengeProposalContentBody({
             type: "success",
             text1: "Submitted",
           });
-          upsetProposalShareModal({ open: true, cast, channel });
+          upsertProposalShareModal({ open: true, cast, channel });
         }}
         onProposeError={(error) => {
           onClose();

--- a/components/social-farcaster/proposal/proposal-modals/ChallengeProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ChallengeProposalModal.tsx
@@ -24,6 +24,7 @@ import { DialogCastActivitiesList } from "~/components/activity/Activities";
 import { SceneMap, TabView } from "react-native-tab-view";
 import DialogTabBar from "~/components/layout/tab-view/DialogTabBar";
 import { AboutProposalChallenge } from "./AboutProposal";
+import useAppModals from "~/hooks/useAppModals";
 
 export type CastProposeStatusProps = {
   cast: NeynarCast;
@@ -141,6 +142,7 @@ function ChallengeProposalContentBody({
 }: CastProposeStatusProps & {
   onClose: () => void;
 }) {
+  const { upsetProposalShareModal } = useAppModals();
   return (
     <View className="flex w-full flex-col gap-4">
       <View className="flex-row items-center justify-between gap-2">
@@ -167,6 +169,7 @@ function ChallengeProposalContentBody({
             type: "success",
             text1: "Submitted",
           });
+          upsetProposalShareModal({ open: true, cast, channel });
         }}
         onDisputeError={(error) => {
           onClose();
@@ -182,6 +185,7 @@ function ChallengeProposalContentBody({
             type: "success",
             text1: "Submitted",
           });
+          upsetProposalShareModal({ open: true, cast, channel });
         }}
         onProposeError={(error) => {
           onClose();

--- a/components/social-farcaster/proposal/proposal-modals/CreateProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/CreateProposalModal.tsx
@@ -22,6 +22,7 @@ import { getProposalMinPrice } from "../utils";
 import { AboutProposalChallenge } from "./AboutProposal";
 import { PriceRangeRow } from "./ChallengeProposalModal";
 import PriceRow from "./PriceRow";
+import useAppModals from "~/hooks/useAppModals";
 
 export type CastProposeStatusProps = {
   cast: NeynarCast;
@@ -107,6 +108,7 @@ function CreateProposalModalContentBodyScene() {
     AttentionTokenEntity | undefined
   >(tokenInfo);
   const { upsertOneToAttTokens } = useCacheCastAttToken();
+  const { upsetProposalShareModal } = useAppModals();
   return (
     <ScrollView
       className="max-h-[80vh] w-full"
@@ -125,6 +127,11 @@ function CreateProposalModalContentBodyScene() {
                 text1: "Upvote successful !",
               });
               setOpen(false);
+              upsetProposalShareModal({
+                open: true,
+                cast,
+                channel,
+              });
             }}
             onCreateProposalError={(error) => {
               Toast.show({

--- a/components/social-farcaster/proposal/proposal-modals/CreateProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/CreateProposalModal.tsx
@@ -108,7 +108,7 @@ function CreateProposalModalContentBodyScene() {
     AttentionTokenEntity | undefined
   >(tokenInfo);
   const { upsertOneToAttTokens } = useCacheCastAttToken();
-  const { upsetProposalShareModal } = useAppModals();
+  const { upsertProposalShareModal } = useAppModals();
   return (
     <ScrollView
       className="max-h-[80vh] w-full"
@@ -127,7 +127,7 @@ function CreateProposalModalContentBodyScene() {
                 text1: "Upvote successful !",
               });
               setOpen(false);
-              upsetProposalShareModal({
+              upsertProposalShareModal({
                 open: true,
                 cast,
                 channel,

--- a/components/social-farcaster/proposal/proposal-modals/ProposalShareGlobalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ProposalShareGlobalModal.tsx
@@ -1,0 +1,36 @@
+import PlatformSharingModal from "~/components/platform-sharing/PlatformSharingModal";
+import { appModalsStateDefalut } from "~/features/appModalsSlice";
+import useAppModals from "~/hooks/useAppModals";
+import { getCastHex } from "~/utils/farcaster/cast-utils";
+import {
+  getCastDetailWebsiteLink,
+  getVoteProposalFrameLink,
+} from "~/utils/platform-sharing/link";
+import {
+  getCastProposalShareTextWithTwitter,
+  getCastProposalShareTextWithWarpcast,
+} from "~/utils/platform-sharing/text";
+
+export default function ProposalShareGlobalModal() {
+  const { proposalShareModal, upsetProposalShareModal } = useAppModals();
+  const { cast, channel } = proposalShareModal;
+  return (
+    <PlatformSharingModal
+      modalTitle="Share"
+      open={proposalShareModal.open}
+      onOpenChange={(open) => {
+        upsetProposalShareModal({ open });
+      }}
+      warpcastText={getCastProposalShareTextWithWarpcast()}
+      twitterText={getCastProposalShareTextWithTwitter()}
+      websiteLink={getCastDetailWebsiteLink(getCastHex(cast!))}
+      warpcastEmbeds={[getVoteProposalFrameLink(getCastHex(cast!))]}
+      warpcastChannelId={channel?.channelId}
+      hideWarpcastPoints
+      hideTwitterPoints
+      navigateToCreatePageAfter={() => {
+        upsetProposalShareModal(appModalsStateDefalut.proposalShareModal);
+      }}
+    />
+  );
+}

--- a/components/social-farcaster/proposal/proposal-modals/ProposalShareGlobalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ProposalShareGlobalModal.tsx
@@ -12,14 +12,14 @@ import {
 } from "~/utils/platform-sharing/text";
 
 export default function ProposalShareGlobalModal() {
-  const { proposalShareModal, upsetProposalShareModal } = useAppModals();
+  const { proposalShareModal, upsertProposalShareModal } = useAppModals();
   const { cast, channel } = proposalShareModal;
   return (
     <PlatformSharingModal
       modalTitle="Share"
       open={proposalShareModal.open}
       onOpenChange={(open) => {
-        upsetProposalShareModal({ open });
+        upsertProposalShareModal({ open });
       }}
       warpcastText={getCastProposalShareTextWithWarpcast()}
       twitterText={getCastProposalShareTextWithTwitter()}
@@ -29,7 +29,7 @@ export default function ProposalShareGlobalModal() {
       hideWarpcastPoints
       hideTwitterPoints
       navigateToCreatePageAfter={() => {
-        upsetProposalShareModal(appModalsStateDefalut.proposalShareModal);
+        upsertProposalShareModal(appModalsStateDefalut.proposalShareModal);
       }}
     />
   );

--- a/components/social-farcaster/proposal/proposal-modals/ProposedProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ProposedProposalModal.tsx
@@ -33,6 +33,7 @@ import { Loading } from "~/components/common/Loading";
 import { Button, ButtonProps } from "~/components/ui/button";
 import { useAccount } from "wagmi";
 import useWalletAccount from "~/hooks/user/useWalletAccount";
+import useAppModals from "~/hooks/useAppModals";
 
 export type CastProposeStatusProps = {
   cast: NeynarCast;
@@ -182,6 +183,8 @@ function ProposedProposalModalContentBodyScene() {
     priceSliderConfig.min,
     paymentTokenInfo!,
   );
+
+  const { upsetProposalShareModal } = useAppModals();
   return (
     <ScrollView
       className="max-h-[80vh] w-full"
@@ -282,6 +285,11 @@ function ProposedProposalModalContentBodyScene() {
                     type: "success",
                     text1: "Submitted",
                   });
+                  upsetProposalShareModal({
+                    open: true,
+                    cast,
+                    channel,
+                  });
                 }}
                 onDisputeError={(error) => {
                   setOpen(false);
@@ -307,6 +315,11 @@ function ProposedProposalModalContentBodyScene() {
                     text1: "Voting speeds up success",
                   });
                   setOpen(false);
+                  upsetProposalShareModal({
+                    open: true,
+                    cast,
+                    channel,
+                  });
                 }}
                 onProposeError={(error) => {
                   Toast.show({

--- a/components/social-farcaster/proposal/proposal-modals/ProposedProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/ProposedProposalModal.tsx
@@ -184,7 +184,7 @@ function ProposedProposalModalContentBodyScene() {
     paymentTokenInfo!,
   );
 
-  const { upsetProposalShareModal } = useAppModals();
+  const { upsertProposalShareModal } = useAppModals();
   return (
     <ScrollView
       className="max-h-[80vh] w-full"
@@ -285,7 +285,7 @@ function ProposedProposalModalContentBodyScene() {
                     type: "success",
                     text1: "Submitted",
                   });
-                  upsetProposalShareModal({
+                  upsertProposalShareModal({
                     open: true,
                     cast,
                     channel,
@@ -315,7 +315,7 @@ function ProposedProposalModalContentBodyScene() {
                     text1: "Voting speeds up success",
                   });
                   setOpen(false);
-                  upsetProposalShareModal({
+                  upsertProposalShareModal({
                     open: true,
                     cast,
                     channel,

--- a/components/social-farcaster/proposal/proposal-modals/UpvoteProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/UpvoteProposalModal.tsx
@@ -32,7 +32,7 @@ export default function UpvoteProposalModal({
   triggerButton: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
-  const { upsetProposalShareModal } = useAppModals();
+  const { upsertProposalShareModal } = useAppModals();
   return (
     <Dialog
       onOpenChange={(open) => {
@@ -61,7 +61,7 @@ export default function UpvoteProposalModal({
                 text1: "Voting speeds up success",
               });
               setOpen(false);
-              upsetProposalShareModal({ open: true, cast, channel });
+              upsertProposalShareModal({ open: true, cast, channel });
             }}
             onProposeError={(error) => {
               Toast.show({

--- a/components/social-farcaster/proposal/proposal-modals/UpvoteProposalModal.tsx
+++ b/components/social-farcaster/proposal/proposal-modals/UpvoteProposalModal.tsx
@@ -15,6 +15,7 @@ import Toast from "react-native-toast-message";
 import { ProposeProposalWriteButton } from "../proposal-write-buttons/ProposalWriteButton";
 import { Slider } from "~/components/ui/slider";
 import { PriceRangeRow } from "./ChallengeProposalModal";
+import useAppModals from "~/hooks/useAppModals";
 
 export type CastProposeStatusProps = {
   cast: NeynarCast;
@@ -31,6 +32,7 @@ export default function UpvoteProposalModal({
   triggerButton: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const { upsetProposalShareModal } = useAppModals();
   return (
     <Dialog
       onOpenChange={(open) => {
@@ -59,6 +61,7 @@ export default function UpvoteProposalModal({
                 text1: "Voting speeds up success",
               });
               setOpen(false);
+              upsetProposalShareModal({ open: true, cast, channel });
             }}
             onProposeError={(error) => {
               Toast.show({

--- a/features/appModalsSlice.ts
+++ b/features/appModalsSlice.ts
@@ -24,7 +24,7 @@ export const appModalsSlice = createSlice({
   name: "appModals",
   initialState: appModalsStateDefalut,
   reducers: {
-    upsetProposalShareModal: (
+    upsertProposalShareModal: (
       state,
       action: PayloadAction<{ open: boolean; castHash?: string }>,
     ) => {
@@ -37,6 +37,6 @@ export const appModalsSlice = createSlice({
 });
 
 const { actions, reducer } = appModalsSlice;
-export const { upsetProposalShareModal } = actions;
+export const { upsertProposalShareModal } = actions;
 export const selectAppModals = (state: RootState) => state.appModals;
 export default reducer;

--- a/features/appModalsSlice.ts
+++ b/features/appModalsSlice.ts
@@ -1,0 +1,42 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { CommunityEntity } from "~/services/community/types/community";
+import { NeynarCast } from "~/services/farcaster/types/neynar";
+import { RootState } from "~/store/store";
+
+export type ProposalShareModal = {
+  open: boolean;
+  cast?: NeynarCast | null;
+  channel?: CommunityEntity | null;
+};
+export type AppModalsState = {
+  proposalShareModal: ProposalShareModal;
+};
+
+export const appModalsStateDefalut: AppModalsState = {
+  proposalShareModal: {
+    open: false,
+    cast: null,
+    channel: null,
+  },
+};
+
+export const appModalsSlice = createSlice({
+  name: "appModals",
+  initialState: appModalsStateDefalut,
+  reducers: {
+    upsetProposalShareModal: (
+      state,
+      action: PayloadAction<{ open: boolean; castHash?: string }>,
+    ) => {
+      state.proposalShareModal = {
+        ...state.proposalShareModal,
+        ...action.payload,
+      };
+    },
+  },
+});
+
+const { actions, reducer } = appModalsSlice;
+export const { upsetProposalShareModal } = actions;
+export const selectAppModals = (state: RootState) => state.appModals;
+export default reducer;

--- a/hooks/useAppModals.ts
+++ b/hooks/useAppModals.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+import {
+  ProposalShareModal,
+  selectAppModals,
+  upsetProposalShareModal,
+} from "~/features/appModalsSlice";
+import { useAppDispatch, useAppSelector } from "~/store/hooks";
+
+export default function useAppModals() {
+  const dispatch = useAppDispatch();
+  const { proposalShareModal } = useAppSelector(selectAppModals);
+
+  const upsetProposalShareModalAction = useCallback(
+    (data: ProposalShareModal) => {
+      dispatch(upsetProposalShareModal(data));
+    },
+    [],
+  );
+
+  return {
+    proposalShareModal,
+    upsetProposalShareModal: upsetProposalShareModalAction,
+  };
+}

--- a/hooks/useAppModals.ts
+++ b/hooks/useAppModals.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import {
   ProposalShareModal,
   selectAppModals,
-  upsetProposalShareModal,
+  upsertProposalShareModal,
 } from "~/features/appModalsSlice";
 import { useAppDispatch, useAppSelector } from "~/store/hooks";
 
@@ -10,15 +10,15 @@ export default function useAppModals() {
   const dispatch = useAppDispatch();
   const { proposalShareModal } = useAppSelector(selectAppModals);
 
-  const upsetProposalShareModalAction = useCallback(
+  const upsertProposalShareModalAction = useCallback(
     (data: ProposalShareModal) => {
-      dispatch(upsetProposalShareModal(data));
+      dispatch(upsertProposalShareModal(data));
     },
     [],
   );
 
   return {
     proposalShareModal,
-    upsetProposalShareModal: upsetProposalShareModalAction,
+    upsertProposalShareModal: upsertProposalShareModalAction,
   };
 }

--- a/store/store.ts
+++ b/store/store.ts
@@ -41,6 +41,7 @@ import exploreTrendingChannels from "~/features/community/exploreTrendingChannel
 import exploreFollowingChannels from "~/features/community/exploreFollowingChannelsSlice";
 import exploreHostingChannels from "~/features/community/exploreHostingChannelsSlice";
 import appSettings from "~/features/appSettingsSlice";
+import appModals from "~/features/appModalsSlice";
 // import userTips from "~/features/user/tipsSlice";
 
 enableMapSet();
@@ -78,6 +79,7 @@ export const store = configureStore({
     castReactions,
     embedCasts,
     appSettings,
+    appModals,
     castProposal,
     castAttToken,
     // userTips,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a `ProposalShareGlobalModal` for sharing proposals across platforms.
  - Added immediate feedback modals upon successful proposal actions (submission, upvote).

- **Bug Fixes**
  - Streamlined the loading indicators for a more consistent user experience.

- **Chores**
  - Enhanced state management for modal displays using a new Redux slice and custom hook.

- **Documentation**
  - Improved user interactions with modals for proposal sharing, leading to a more responsive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->