### PR TITLE
hide opensea link conditional

### DIFF
--- a/components/trade/ATTExternalLink.tsx
+++ b/components/trade/ATTExternalLink.tsx
@@ -5,6 +5,7 @@ import { kebabCase } from "lodash";
 import { Button } from "../ui/button";
 import { Text } from "../ui/text";
 import { cn } from "~/lib/utils";
+import useATTNftInfo from "~/hooks/trade/useATTNftInfo";
 
 export default function ATTExternalLink({
   contractAddress,
@@ -15,9 +16,13 @@ export default function ATTExternalLink({
   tokenId?: string | number;
   className?: string;
 }) {
+  const { totalNFTSupply } = useATTNftInfo({
+    tokenContract: contractAddress as `0x${string}`,
+  });
+  if (!totalNFTSupply) return null;
   return (
     <ExternalLink
-      href={`https://${ATT_CONTRACT_CHAIN.testnet ? "testnets.":""}opensea.io/assets/${kebabCase(ATT_CONTRACT_CHAIN.name)}/${contractAddress}/${tokenId === undefined ? "" : tokenId}`}
+      href={`https://${ATT_CONTRACT_CHAIN.testnet ? "testnets." : ""}opensea.io/assets/${kebabCase(ATT_CONTRACT_CHAIN.name)}/${contractAddress}/${tokenId === undefined ? "" : tokenId}`}
       target="_blank"
     >
       <Button

--- a/hooks/trade/useATTNftInfo.ts
+++ b/hooks/trade/useATTNftInfo.ts
@@ -9,13 +9,15 @@ import { useATTContractInfo } from "./useATTContract";
 
 export default function useATTNftInfo({
   tokenContract,
+  tokenId,
 }: {
   tokenContract: `0x${string}`;
+  tokenId?: number;
 }) {
   const account = useAccount();
   const { getPaymentToken, getGraduated } = useATTFactoryContractInfo({
     contractAddress: tokenContract,
-    tokenId: 0,
+    tokenId: tokenId || 0,
   });
   const {
     tokenUnit: getTokenUnit,
@@ -31,8 +33,10 @@ export default function useATTNftInfo({
   const { data: totalNFTSupply } = getTotalNFTSupply();
   const { paymentToken } = getPaymentToken();
   const [token, setToken] = useState<TokenWithTradeInfo | undefined>(undefined);
-  
-  const [nftTokenInfo, setNftTokenInfo] = useState<TokenWithTradeInfo | undefined>(undefined);
+
+  const [nftTokenInfo, setNftTokenInfo] = useState<
+    TokenWithTradeInfo | undefined
+  >(undefined);
 
   useEffect(() => {
     if (paymentToken && account?.address)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `ATTExternalLink` component to conditionally render based on NFT supply availability.
	- Introduced a new optional `tokenId` parameter in the `useATTNftInfo` hook for improved flexibility.

- **Bug Fixes**
	- Prevented rendering of the `ExternalLink` component when NFT supply data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->