### PR TITLE
fix: home symbol

### DIFF
--- a/components/social-farcaster/proposal/proposal-status-actions/MintAction.tsx
+++ b/components/social-farcaster/proposal/proposal-status-actions/MintAction.tsx
@@ -51,7 +51,10 @@ export function ReadyToMintButton({
             <ProposalButton variant={"ready-to-mint"} {...props}>
               {/* <DiamondPlus className="size-4 stroke-proposalReadyToMint-foreground" /> */}
               <ProposalText>
-                Mint for ${channel.channelId?.toLocaleUpperCase()}
+                Mint for $
+                {channel.channelId === "home"
+                  ? "CAST"
+                  : channel.channelId?.toLocaleUpperCase()}
               </ProposalText>
             </ProposalButton>
           );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The minting action button now conditionally displays text based on the channel ID, enhancing user clarity.
	- If the channel ID is "home," the button will show "CAST"; otherwise, it will display the channel ID in uppercase. 

- **Bug Fixes**
	- Retained commented-out code for potential future use without impacting current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->